### PR TITLE
Message ranking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
       run: |
         mypy .
 
-#    - name: Run tests
-#      run: |
-#        python -m pytest --cov=src --cov-report term-missing .
+    - name: Run tests
+      run: |
+        python -m pytest --cov=src --cov-fail-under 50 --cov-report term-missing .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements-dev.txt
+        python -m pip install -r requirements.txt
 
     - name: Check with isort
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+networkx==2.6.3
+nltk==3.7
+numpy==1.22.2
 python-telegram-bot==13.10
+scikit-learn==1.0.2

--- a/src/ranker.py
+++ b/src/ranker.py
@@ -32,7 +32,7 @@ def textrank(documents: List[str], threshold_bias: float = 0.2) -> List[str]:
 
     # normalize scores
     if f_min == f_max:
-        temp_array = [0.] * len(document_array)
+        temp_array = [0.0] * len(document_array)
     else:
         temp_array = [
             (float(score) - f_min) / (f_max - f_min) for score, _ in document_array

--- a/src/ranker.py
+++ b/src/ranker.py
@@ -32,7 +32,7 @@ def textrank(documents: List[str], threshold_bias: float = 0.2) -> List[str]:
 
     # normalize scores
     if f_min == f_max:
-        temp_array = [0] * len(document_array)
+        temp_array = [0.] * len(document_array)
     else:
         temp_array = [
             (float(score) - f_min) / (f_max - f_min) for score, _ in document_array

--- a/src/ranker.py
+++ b/src/ranker.py
@@ -1,0 +1,53 @@
+from typing import List
+
+import networkx as nx
+import numpy as np
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+
+
+def textrank(documents: List[str], threshold_bias: float = 0.2) -> List[str]:
+    """
+    Get the most relevant documents from the array of documents
+    :param documents: List[str], original array of documents to filter
+    :param threshold_bias: float, additional bias for the computed mean document score
+    :return: List[str], array of the most relevant documents in the original order
+    """
+    bow_matrix = CountVectorizer().fit_transform(documents)
+    tfidf_matrix = TfidfTransformer().fit_transform(bow_matrix)
+
+    similarity_matrix = tfidf_matrix * tfidf_matrix.T
+
+    nx_graph = nx.from_scipy_sparse_matrix(similarity_matrix)
+    scores = nx.pagerank(nx_graph)
+
+    document_array = np.asarray(
+        sorted(
+            ((scores[i], document) for i, document in enumerate(documents)),
+            reverse=True,
+        )
+    )
+
+    f_max = float(document_array[0][0])
+    f_min = float(document_array[-1][0])
+
+    # normalize scores
+    if f_min == f_max:
+        temp_array = [0] * len(document_array)
+    else:
+        temp_array = [
+            (float(score) - f_min) / (f_max - f_min) for score, _ in document_array
+        ]
+
+    threshold = (sum(temp_array) / len(temp_array)) + threshold_bias
+
+    # filter documents by score
+    document_list = [
+        document
+        for (_, document), score in zip(document_array, temp_array)
+        if score > threshold
+    ]
+
+    # restore the original order of documents
+    seq_list = [document for document in documents if document in document_list]
+
+    return seq_list

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -1,0 +1,8 @@
+from src.ranker import textrank
+
+
+def test_ranker_works_correctly():
+    expected_output = []
+    documents = ["hello", "goodbye"]
+    output = textrank(documents)
+    assert expected_output == output, f"Expected empty output but got {output}"

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -1,8 +1,10 @@
+from typing import List
+
 from src.ranker import textrank
 
 
-def test_ranker_works_correctly():
-    expected_output = []
+def test_ranker_works_correctly() -> None:
+    expected_output: List[str] = []
     documents = ["hello", "goodbye"]
     output = textrank(documents)
     assert expected_output == output, f"Expected empty output but got {output}"


### PR DESCRIPTION
Пока сделал так, что на выходе функции ранжирования отфильтрованный список текстов.

После окончательной реализации деплоя и сбора сообщений станет понятнее, но в данный момент думаю, что возвращать надо не сами тексты, а их индексы во входном массиве. Мотивация: хранимые в БД объекты, помимо самих текстов, будут содержать ещё ссылку на сообщение, автора, таймкод, ну и/или что там ещё нам может понадобиться... После ранжирования по полученным индексам будем фильтровать нерелевантные объекты.

Closes #3.